### PR TITLE
Add e2e compose stack and env generation helper

### DIFF
--- a/.env.e2e.example
+++ b/.env.e2e.example
@@ -1,0 +1,25 @@
+# Telegram
+TELEGRAM_BOT_TOKEN=__E2E_TELEGRAM_BOT_TOKEN__
+
+# Admin (SQLAdmin/ingest)
+ADMIN_ENABLED=true
+ADMIN_TOKEN=change_me_admin_bearer
+
+# Postgres (internal connection)
+POSTGRES_DB=dnd_helper_e2e
+POSTGRES_USER=dnd_helper_e2e
+POSTGRES_PASSWORD=change_me_e2e
+POSTGRES_HOST=postgres
+POSTGRES_PORT=5432
+
+# Redis
+REDIS_URL=redis://redis:6379/0
+
+# Host port overrides to avoid clashes with dev compose
+API_E2E_PORT=18000
+POSTGRES_E2E_PORT=55432
+REDIS_E2E_PORT=16379
+
+# Bot container user (falls back to UID/GID 1000 if unset)
+LOCAL_UID=1000
+LOCAL_GID=1000

--- a/.gitignore
+++ b/.gitignore
@@ -67,7 +67,9 @@ logs/
 # Environment variables
 .env
 .env.*
+.env.e2e
 !.env.example
+!.env.e2e.example
 
 # Local data / temp
 tmp/

--- a/README.md
+++ b/README.md
@@ -51,6 +51,35 @@ POSTGRES_PORT=5432
 REDIS_URL=redis://redis:6379/0
 ```
 
+### End-to-end (E2E) stack
+
+The repository ships a dedicated compose stack for end-to-end runs so that it can run
+next to the default development stack without clashing on container names, volumes, or
+exposed ports.
+
+1. Generate the E2E environment file from the example template:
+
+   ```bash
+   # pass the token explicitly or via the E2E_TELEGRAM_BOT_TOKEN env variable
+   python scripts/generate_e2e_env.py --token <telegram-bot-token>
+   ```
+
+   The helper copies `.env.e2e.example` to `.env.e2e` and injects the Telegram token.
+   Re-run with `--force` to overwrite an existing file.
+
+2. Start the stack with the E2E compose file:
+
+   ```bash
+   docker compose -f docker-compose.e2e.yml up -d
+   ```
+
+   Services reuse the same Dockerfiles but are scoped under
+   `${COMPOSE_PROJECT_NAME:-dnd-e2e}`. By default the stack exposes API on `18000`,
+   Postgres on `55432`, and Redis on `16379` (override via `API_E2E_PORT`,
+   `POSTGRES_E2E_PORT`, `REDIS_E2E_PORT`). Internal connection variables stay the same
+   (`POSTGRES_HOST=postgres`, `POSTGRES_PORT=5432`, etc.), so application code does not
+   need additional conditionals.
+
 ### Quick Start (local/dev)
 1. For a clean environment with seed data and translations:
    - Prepare a bundle under `data/seed_bundle/` (see `docs/architecture.md` for required files).

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -1,0 +1,72 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: "${COMPOSE_PROJECT_NAME:-dnd-e2e}_postgres"
+    restart: unless-stopped
+    env_file:
+      - .env.e2e
+    ports:
+      - "${POSTGRES_E2E_PORT:-55432}:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  redis:
+    image: redis:7-alpine
+    container_name: "${COMPOSE_PROJECT_NAME:-dnd-e2e}_redis"
+    restart: unless-stopped
+    ports:
+      - "${REDIS_E2E_PORT:-16379}:6379"
+    volumes:
+      - redis_data:/data
+
+  api:
+    build:
+      context: .
+      dockerfile: api/Dockerfile
+    container_name: "${COMPOSE_PROJECT_NAME:-dnd-e2e}_api"
+    restart: unless-stopped
+    env_file:
+      - .env.e2e
+    environment:
+      - PYTHONPATH=/app/src
+      - LOG_LEVEL=${LOG_LEVEL:-INFO}
+      - LOG_JSON=${LOG_JSON:-true}
+      - LOG_SERVICE_NAME=api
+    depends_on:
+      - postgres
+      - redis
+    ports:
+      - "${API_E2E_PORT:-18000}:8000"
+    command: python -m dnd_helper_api.main
+    volumes:
+      - ./api/alembic/versions:/app/alembic/versions
+      - ./data/admin_uploads:/data/admin_uploads
+
+  bot:
+    build:
+      context: ./bot
+      dockerfile: Dockerfile
+    container_name: "${COMPOSE_PROJECT_NAME:-dnd-e2e}_bot"
+    restart: unless-stopped
+    env_file:
+      - .env.e2e
+    environment:
+      - PYTHONPATH=/app/src
+      - LOG_LEVEL=${LOG_LEVEL:-INFO}
+      - LOG_JSON=${LOG_JSON:-true}
+      - LOG_SERVICE_NAME=bot
+    user: "${LOCAL_UID:-1000}:${LOCAL_GID:-1000}"
+    depends_on:
+      - redis
+      - postgres
+    command: python -m dnd_helper_bot.main
+
+volumes:
+  postgres_data:
+    name: "${COMPOSE_PROJECT_NAME:-dnd-e2e}_postgres_data"
+  redis_data:
+    name: "${COMPOSE_PROJECT_NAME:-dnd-e2e}_redis_data"
+
+networks:
+  default:
+    name: "${COMPOSE_PROJECT_NAME:-dnd-e2e}_network"

--- a/scripts/generate_e2e_env.py
+++ b/scripts/generate_e2e_env.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Helper for generating .env.e2e from the checked-in example."""
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+EXAMPLE_FILE = PROJECT_ROOT / ".env.e2e.example"
+TARGET_FILE = PROJECT_ROOT / ".env.e2e"
+TOKEN_PLACEHOLDER_PATTERN = re.compile(r"^TELEGRAM_BOT_TOKEN=.*$", re.MULTILINE)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Copy .env.e2e.example to .env.e2e and optionally inject a Telegram bot token. "
+            "The token can be passed via --token or E2E_TELEGRAM_BOT_TOKEN."
+        )
+    )
+    parser.add_argument(
+        "--token",
+        dest="token",
+        help="Telegram bot token to write into TELEGRAM_BOT_TOKEN. Overrides environment variable.",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite an existing .env.e2e file instead of failing.",
+    )
+    return parser.parse_args()
+
+
+def load_example() -> str:
+    if not EXAMPLE_FILE.exists():
+        raise SystemExit(".env.e2e.example is missing; cannot generate .env.e2e")
+    return EXAMPLE_FILE.read_text()
+
+
+def apply_token(contents: str, token: str | None) -> str:
+    if not token:
+        return contents
+    if TOKEN_PLACEHOLDER_PATTERN.search(contents):
+        return TOKEN_PLACEHOLDER_PATTERN.sub(f"TELEGRAM_BOT_TOKEN={token}", contents)
+    return f"TELEGRAM_BOT_TOKEN={token}\n{contents}"
+
+
+def write_env(contents: str, force: bool) -> None:
+    if TARGET_FILE.exists() and not force:
+        raise SystemExit(
+            ".env.e2e already exists. Pass --force to overwrite or remove the file manually."
+        )
+    TARGET_FILE.write_text(contents)
+
+
+def main() -> None:
+    args = parse_args()
+    token = args.token or os.environ.get("E2E_TELEGRAM_BOT_TOKEN")
+    contents = load_example()
+    contents = apply_token(contents, token)
+    write_env(contents, force=args.force)
+    if token:
+        print("Written .env.e2e with TELEGRAM_BOT_TOKEN from provided token.")
+    else:
+        print("Written .env.e2e using example values (TELEGRAM_BOT_TOKEN left as placeholder).")
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add a dedicated docker-compose.e2e.yml that scopes containers, volumes, and networks for e2e usage
- document the e2e stack and provide a .env.e2e example with isolated defaults
- ship a helper script to generate .env.e2e and inject a Telegram token without hard-coding secrets

## Testing
- ./run_test.sh *(fails: docker: command not found)*
- docker compose up -d *(fails: docker: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ca1370f79c8325a5e79abb5e416c6a